### PR TITLE
fix: flex functions do not support UserAssigned identity access to KV

### DIFF
--- a/modules/azure-flex-function/README.md
+++ b/modules/azure-flex-function/README.md
@@ -237,4 +237,6 @@ The module will create resources with these names:
 | <a name="output_service_principal_object_id"></a> [service\_principal\_object\_id](#output\_service\_principal\_object\_id) | The object ID of the service principal |
 | <a name="output_storage_account_id"></a> [storage\_account\_id](#output\_storage\_account\_id) | The ID of the storage account used by the Function App |
 | <a name="output_storage_account_name"></a> [storage\_account\_name](#output\_storage\_account\_name) | The name of the storage account used by the Function App |
+| <a name="output_system_assigned_principal_id"></a> [system\_assigned\_principal\_id](#output\_system\_assigned\_principal\_id) | System-assigned managed identity principal ID for the Function App. Null when app identity type is UserAssigned only. |
+| <a name="output_system_assigned_tenant_id"></a> [system\_assigned\_tenant\_id](#output\_system\_assigned\_tenant\_id) | Tenant ID of the Function App system-assigned managed identity. Null when app identity type is UserAssigned only. |
 <!-- END_TF_DOCS -->

--- a/modules/azure-flex-function/main.tf
+++ b/modules/azure-flex-function/main.tf
@@ -41,6 +41,12 @@ locals {
   storage_account_name   = lower(coalesce(var.storage_account_name, "${local.prefix}${local.environment}sa${local.clean_base_name}"))
   plan_name              = coalesce(var.plan_name, "${local.prefix}-${local.environment}-fcplan-${var.base_name}")
   deployment_container   = "deployments"
+
+  # Only enable SystemAssigned identity when Keyvault is present 
+  has_key_vault = var.key_vault != null 
+  function_identity_type = local.has_key_vault ? "SystemAssigned, UserAssigned" : "UserAssigned"
+  # If Key Vault is enabled, grant KV access to system identity (default KV reference identity on Flex)
+  key_vault_object_id = local.has_key_vault ? azurerm_function_app_flex_consumption.app.identity[0].principal_id : azurerm_user_assigned_identity.app.principal_id
 }
 
 # ------------------------------------------------------------------------
@@ -182,7 +188,7 @@ resource "azurerm_function_app_flex_consumption" "app" {
   app_settings = local.app_settings
 
   identity {
-    type         = "UserAssigned"
+    type         = local.function_identity_type
     identity_ids = [azurerm_user_assigned_identity.app.id]
   }
 
@@ -231,7 +237,7 @@ resource "azurerm_key_vault_access_policy" "app" {
   count        = var.key_vault != null ? 1 : 0
   key_vault_id = data.azurerm_key_vault.key_vault[0].id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = azurerm_user_assigned_identity.app.principal_id
+  object_id    = local.key_vault_object_id
 
   secret_permissions = [
     "Get",

--- a/modules/azure-flex-function/outputs.tf
+++ b/modules/azure-flex-function/outputs.tf
@@ -62,3 +62,19 @@ output "service_principal_object_id" {
   value       = azuread_service_principal.app.object_id
   description = "The object ID of the service principal"
 }
+
+output "system_assigned_principal_id" {
+  description = "System-assigned managed identity principal ID for the Function App. Null when app identity type is UserAssigned only."
+  value = try(
+    azurerm_function_app_flex_consumption.app.identity[0].principal_id,
+    null
+  )
+}
+
+output "system_assigned_tenant_id" {
+  description = "Tenant ID of the Function App system-assigned managed identity. Null when app identity type is UserAssigned only."
+  value = try(
+    azurerm_function_app_flex_consumption.app.identity[0].tenant_id,
+    null
+  )
+}


### PR DESCRIPTION
When using azure-flex-function and keyvault, enable both SystemAssigned and UserAssigned identity and grant the SystemAssigned identity access to the keyvault, because azurerm-flex-function does not support UserAssigned identity access to key vault.