### PR TITLE
fix: function app system assigned id not known until applied

### DIFF
--- a/modules/azure-flex-function/README.md
+++ b/modules/azure-flex-function/README.md
@@ -162,6 +162,7 @@ The module will create resources with these names:
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 2.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.0 |
 
@@ -169,6 +170,7 @@ The module will create resources with these names:
 
 | Name | Version |
 |------|---------|
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | >= 2.0 |
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | >= 2.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.0 |
 
@@ -190,6 +192,7 @@ The module will create resources with these names:
 | [azurerm_service_plan.plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |
 | [azurerm_storage_container.deployment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_user_assigned_identity.app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
+| [azapi_resource.function_site](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/resource) | data source |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |

--- a/modules/azure-flex-function/main.tf
+++ b/modules/azure-flex-function/main.tf
@@ -8,8 +8,14 @@ terraform {
       source  = "hashicorp/azuread"
       version = ">= 2.0"
     }
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 2.0"
+    }
   }
 }
+
+provider "azapi" {}
 
 # ------------------------------------------------------------------------
 # Stores the current connection information (Resource Manager and AD)
@@ -45,8 +51,6 @@ locals {
   # Only enable SystemAssigned identity when Keyvault is present 
   has_key_vault = var.key_vault != null 
   function_identity_type = local.has_key_vault ? "SystemAssigned, UserAssigned" : "UserAssigned"
-  # If Key Vault is enabled, grant KV access to system identity (default KV reference identity on Flex)
-  key_vault_object_id = local.has_key_vault ? azurerm_function_app_flex_consumption.app.identity[0].principal_id : azurerm_user_assigned_identity.app.principal_id
 }
 
 # ------------------------------------------------------------------------
@@ -210,6 +214,26 @@ resource "azurerm_function_app_flex_consumption" "app" {
 }
 
 # ------------------------------------------------------------------------
+# The SystemAssigned identity object_id is not known until applied
+# This allows us to read the identity's principal ID after apply 
+# which is used to grant that identity access to the key vault 
+# in azurerm_key_vault_access_policy.app. Direct usage of the 
+# principalId without this step leads to an empty string result, 
+# causing a failure during plan steps. 
+# NOTE: Once flex consumption apps support UserAssigned identity 
+# access to keyVault references, we can use that rather than 
+# SystemAssigned identities for key vault access in environment variables
+# ------------------------------------------------------------------------
+data "azapi_resource" "function_site" {
+  type        = "Microsoft.Web/sites@2023-12-01"
+  resource_id = azurerm_function_app_flex_consumption.app.id
+
+  response_export_values = ["identity.principalId"]
+
+  depends_on = [azurerm_function_app_flex_consumption.app]
+}
+
+# ------------------------------------------------------------------------
 # Setup slot for function
 # Note: FlexConsumption does not currently support deployment slots
 # This is a placeholder for future support
@@ -237,7 +261,7 @@ resource "azurerm_key_vault_access_policy" "app" {
   count        = var.key_vault != null ? 1 : 0
   key_vault_id = data.azurerm_key_vault.key_vault[0].id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = local.key_vault_object_id
+  object_id    = data.azapi_resource.function_site.output.identity.principalId
 
   secret_permissions = [
     "Get",

--- a/modules/azure-flex-function/tests/azure-flex-function.tftest.hcl
+++ b/modules/azure-flex-function/tests/azure-flex-function.tftest.hcl
@@ -404,3 +404,29 @@ run "should_not_create_deployment_slot" {
     error_message = "Should accept deploy_using_slots variable for future compatibility"
   }
 }
+
+run "should_create_key_vault_access_policy" {
+  command = plan
+
+  variables {
+    key_vault = {
+      name = "mie-shr-kv"
+      resource_group_name = "mie-shr-rg"
+    }
+  }
+
+  assert {
+    condition     = length(azurerm_key_vault_access_policy.app) == 1
+    error_message = "Should create key vault access policy"
+  }
+
+  assert {
+    condition     = length(azurerm_key_vault_access_policy.app[0].key_vault_id) > 1 
+    error_message = "Should set key_vault_id"
+  }
+
+  assert {
+    condition     = length(azurerm_key_vault_access_policy.app[0].tenant_id) > 1 
+    error_message = "Should set tenant_id"
+  }
+}


### PR DESCRIPTION
Flex Consumption function apps do not currently support key vault references using UserAssigned identity. To get around this, this commit assigns the SystemAssigned identity permissions to the key vault to enable access to key vault references in environment variables. Accessing these SystemAssigned identity values requires waiting for the function app to be created before creating the key vault access policy.